### PR TITLE
feat: Implementa Gestão de Coletas (Doações) #57

### DIFF
--- a/amamenta-api/drizzle/0010_bouncy_havok.sql
+++ b/amamenta-api/drizzle/0010_bouncy_havok.sql
@@ -1,0 +1,55 @@
+ALTER TABLE "pasteurization_batches" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "pasteurized_milk_units" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+ALTER TABLE "raw_milk_collections" ADD COLUMN "tenant_id" uuid;--> statement-breakpoint
+UPDATE "raw_milk_collections"
+SET "tenant_id" = "donators"."tenant_id"
+FROM "donators"
+WHERE "raw_milk_collections"."donor_id" = "donators"."id";--> statement-breakpoint
+UPDATE "pasteurization_batches"
+SET "tenant_id" = "batch_tenants"."tenant_id"
+FROM (
+  SELECT
+    "batch_raw_milk"."batch_id",
+    min("raw_milk_collections"."tenant_id"::text)::uuid AS "tenant_id",
+    count(DISTINCT "raw_milk_collections"."tenant_id") AS "tenant_count"
+  FROM "batch_raw_milk"
+  INNER JOIN "raw_milk_collections"
+    ON "batch_raw_milk"."raw_milk_collection_id" = "raw_milk_collections"."id"
+  GROUP BY "batch_raw_milk"."batch_id"
+) AS "batch_tenants"
+WHERE "pasteurization_batches"."id" = "batch_tenants"."batch_id"
+  AND "batch_tenants"."tenant_count" = 1;--> statement-breakpoint
+UPDATE "pasteurized_milk_units"
+SET "tenant_id" = "pasteurization_batches"."tenant_id"
+FROM "pasteurization_batches"
+WHERE "pasteurized_milk_units"."batch_id" = "pasteurization_batches"."id";--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "raw_milk_collections" WHERE "tenant_id" IS NULL) THEN
+    RAISE EXCEPTION 'raw_milk_collections.tenant_id backfill failed';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM "pasteurization_batches" WHERE "tenant_id" IS NULL) THEN
+    RAISE EXCEPTION 'pasteurization_batches.tenant_id backfill failed';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM "pasteurized_milk_units" WHERE "tenant_id" IS NULL) THEN
+    RAISE EXCEPTION 'pasteurized_milk_units.tenant_id backfill failed';
+  END IF;
+END $$;--> statement-breakpoint
+ALTER TABLE "pasteurization_batches" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pasteurized_milk_units" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "raw_milk_collections" ALTER COLUMN "tenant_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "pasteurization_batches" ADD CONSTRAINT "pasteurization_batches_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pasteurized_milk_units" ADD CONSTRAINT "pasteurized_milk_units_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "raw_milk_collections" ADD CONSTRAINT "raw_milk_collections_tenant_id_tenants_id_fk" FOREIGN KEY ("tenant_id") REFERENCES "public"."tenants"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "pasteurization_batches_tenant_id_idx" ON "pasteurization_batches" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "pasteurization_batches_tenant_microbiology_idx" ON "pasteurization_batches" USING btree ("tenant_id","microbiology_status");--> statement-breakpoint
+CREATE INDEX "pasteurization_batches_tenant_operator_idx" ON "pasteurization_batches" USING btree ("tenant_id","operator_id");--> statement-breakpoint
+CREATE INDEX "pasteurized_milk_units_tenant_id_idx" ON "pasteurized_milk_units" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "pasteurized_milk_units_tenant_batch_idx" ON "pasteurized_milk_units" USING btree ("tenant_id","batch_id");--> statement-breakpoint
+CREATE INDEX "pasteurized_milk_units_tenant_stock_idx" ON "pasteurized_milk_units" USING btree ("tenant_id","stock_status");--> statement-breakpoint
+CREATE INDEX "raw_milk_collections_tenant_id_idx" ON "raw_milk_collections" USING btree ("tenant_id");--> statement-breakpoint
+CREATE INDEX "raw_milk_collections_tenant_donor_idx" ON "raw_milk_collections" USING btree ("tenant_id","donor_id");--> statement-breakpoint
+CREATE INDEX "raw_milk_collections_tenant_triage_idx" ON "raw_milk_collections" USING btree ("tenant_id","triage_status");--> statement-breakpoint
+CREATE INDEX "raw_milk_collections_tenant_storage_idx" ON "raw_milk_collections" USING btree ("tenant_id","storage_status");

--- a/amamenta-api/drizzle/meta/0010_snapshot.json
+++ b/amamenta-api/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1661 @@
+{
+  "id": "748dcee5-1589-428e-9c3e-5645e2966907",
+  "prevId": "95709360-9acb-4c66-b587-a923b32a3dd2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.batch_raw_milk": {
+      "name": "batch_raw_milk",
+      "schema": "",
+      "columns": {
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_milk_collection_id": {
+          "name": "raw_milk_collection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "batch_raw_milk_batch_id_raw_milk_collection_id_pk": {
+          "name": "batch_raw_milk_batch_id_raw_milk_collection_id_pk",
+          "columns": [
+            "batch_id",
+            "raw_milk_collection_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "unique_raw_milk": {
+          "name": "unique_raw_milk",
+          "nullsNotDistinct": false,
+          "columns": [
+            "raw_milk_collection_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donator_clinical_histories": {
+      "name": "donator_clinical_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "donator_id": {
+          "name": "donator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profession": {
+          "name": "profession",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marital_status": {
+          "name": "marital_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenatal_type": {
+          "name": "prenatal_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prenatal_location": {
+          "name": "prenatal_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_breastfeeding_guidance": {
+          "name": "received_breastfeeding_guidance",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_first_child": {
+          "name": "is_first_child",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "breastfed_last_child": {
+          "name": "breastfed_last_child",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "breastfed_last_child_duration": {
+          "name": "breastfed_last_child_duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_type": {
+          "name": "delivery_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_weight_grams": {
+          "name": "birth_weight_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gestational_age_initial_weeks": {
+          "name": "gestational_age_initial_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gestational_age_final_weeks": {
+          "name": "gestational_age_final_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gestational_age_days": {
+          "name": "gestational_age_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pregnancy_weight_kg": {
+          "name": "pregnancy_weight_kg",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height_meters": {
+          "name": "height_meters",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pregnancy_intercurrences_cid10": {
+          "name": "pregnancy_intercurrences_cid10",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_smoker": {
+          "name": "is_smoker",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cigarettes_per_day": {
+          "name": "cigarettes_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_alcohol": {
+          "name": "uses_alcohol",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_drugs": {
+          "name": "uses_drugs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uses_medication": {
+          "name": "uses_medication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substance_use_description": {
+          "name": "substance_use_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substance_use_classification": {
+          "name": "substance_use_classification",
+          "type": "substance_use_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "had_blood_transfusion_last_five_years": {
+          "name": "had_blood_transfusion_last_five_years",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_area": {
+          "name": "medical_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declared_fit": {
+          "name": "declared_fit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donator_clinical_histories_donator_id_unique": {
+          "name": "donator_clinical_histories_donator_id_unique",
+          "columns": [
+            {
+              "expression": "donator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donator_clinical_histories_donator_id_donators_id_fk": {
+          "name": "donator_clinical_histories_donator_id_donators_id_fk",
+          "tableFrom": "donator_clinical_histories",
+          "tableTo": "donators",
+          "columnsFrom": [
+            "donator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.donator_exams": {
+      "name": "donator_exams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "donator_id": {
+          "name": "donator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exam_date": {
+          "name": "exam_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vdrl": {
+          "name": "vdrl",
+          "type": "donator_exam_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hbsag": {
+          "name": "hbsag",
+          "type": "donator_exam_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ftaabs": {
+          "name": "ftaabs",
+          "type": "donator_exam_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hiv": {
+          "name": "hiv",
+          "type": "donator_exam_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hb_percentage": {
+          "name": "hb_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ht_percentage": {
+          "name": "ht_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donator_exams_donator_id_idx": {
+          "name": "donator_exams_donator_id_idx",
+          "columns": [
+            {
+              "expression": "donator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donator_exams_valid_until_idx": {
+          "name": "donator_exams_valid_until_idx",
+          "columns": [
+            {
+              "expression": "valid_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "donator_exams_exam_date_idx": {
+          "name": "donator_exams_exam_date_idx",
+          "columns": [
+            {
+              "expression": "exam_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donator_exams_donator_id_donators_id_fk": {
+          "name": "donator_exams_donator_id_donators_id_fk",
+          "tableFrom": "donator_exams",
+          "tableTo": "donators",
+          "columnsFrom": [
+            "donator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "donator_exams_valid_until_after_exam_date_check": {
+          "name": "donator_exams_valid_until_after_exam_date_check",
+          "value": "\"donator_exams\".\"valid_until\" >= \"donator_exams\".\"exam_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.donators": {
+      "name": "donators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'TO'"
+        },
+        "reference_point": {
+          "name": "reference_point",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baby_name": {
+          "name": "baby_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naturality": {
+          "name": "naturality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_collection": {
+          "name": "home_collection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "exclusive_donator": {
+          "name": "exclusive_donator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "receptor": {
+          "name": "receptor",
+          "type": "donator_receptor",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receptor_other": {
+          "name": "receptor_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guidance_source": {
+          "name": "guidance_source",
+          "type": "donator_guidance_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guidance_source_other": {
+          "name": "guidance_source_other",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by": {
+          "name": "registered_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "donator_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING_EXAMS'"
+        },
+        "last_collection_date": {
+          "name": "last_collection_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "donator_phone_tenant_unique": {
+          "name": "donator_phone_tenant_unique",
+          "columns": [
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "donators_user_id_users_id_fk": {
+          "name": "donators_user_id_users_id_fk",
+          "tableFrom": "donators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "donators_tenant_id_tenants_id_fk": {
+          "name": "donators_tenant_id_tenants_id_fk",
+          "tableFrom": "donators",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "employees_tenant_email_unique": {
+          "name": "employees_tenant_email_unique",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "employees_tenant_idx": {
+          "name": "employees_tenant_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "employees_tenant_id_tenants_id_fk": {
+          "name": "employees_tenant_id_tenants_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tenants": {
+      "name": "tenants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_join_by_domain": {
+          "name": "auto_join_by_domain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tenants_domain_unique": {
+          "name": "tenants_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_secret": {
+          "name": "two_factor_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_tenant_id_tenants_id_fk": {
+          "name": "users_tenant_id_tenants_id_fk",
+          "tableFrom": "users",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invites_token_unique": {
+          "name": "invites_token_unique",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_tenant_id_tenants_id_fk": {
+          "name": "invites_tenant_id_tenants_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pasteurization_batches": {
+      "name": "pasteurization_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_code": {
+          "name": "batch_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pasteurized_at": {
+          "name": "pasteurized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator_id": {
+          "name": "operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "microbiology_status": {
+          "name": "microbiology_status",
+          "type": "microbiology_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pasteurization_batches_tenant_id_idx": {
+          "name": "pasteurization_batches_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pasteurization_batches_tenant_microbiology_idx": {
+          "name": "pasteurization_batches_tenant_microbiology_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "microbiology_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pasteurization_batches_tenant_operator_idx": {
+          "name": "pasteurization_batches_tenant_operator_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pasteurization_batches_tenant_id_tenants_id_fk": {
+          "name": "pasteurization_batches_tenant_id_tenants_id_fk",
+          "tableFrom": "pasteurization_batches",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pasteurized_milk_units": {
+      "name": "pasteurized_milk_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_status": {
+          "name": "stock_status",
+          "type": "pasteurized_milk_stock_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distributed_at": {
+          "name": "distributed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discard_reason": {
+          "name": "discard_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_identifier": {
+          "name": "recipient_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pasteurized_milk_units_tenant_id_idx": {
+          "name": "pasteurized_milk_units_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pasteurized_milk_units_tenant_batch_idx": {
+          "name": "pasteurized_milk_units_tenant_batch_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pasteurized_milk_units_tenant_stock_idx": {
+          "name": "pasteurized_milk_units_tenant_stock_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pasteurized_milk_units_tenant_id_tenants_id_fk": {
+          "name": "pasteurized_milk_units_tenant_id_tenants_id_fk",
+          "tableFrom": "pasteurized_milk_units",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_milk_collections": {
+      "name": "raw_milk_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "donor_id": {
+          "name": "donor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_ml": {
+          "name": "volume_ml",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triage_status": {
+          "name": "triage_status",
+          "type": "raw_milk_triage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_status": {
+          "name": "storage_status",
+          "type": "raw_milk_storage_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discard_reason": {
+          "name": "discard_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "raw_milk_collections_tenant_id_idx": {
+          "name": "raw_milk_collections_tenant_id_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_milk_collections_tenant_donor_idx": {
+          "name": "raw_milk_collections_tenant_donor_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "donor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_milk_collections_tenant_triage_idx": {
+          "name": "raw_milk_collections_tenant_triage_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "raw_milk_collections_tenant_storage_idx": {
+          "name": "raw_milk_collections_tenant_storage_idx",
+          "columns": [
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "raw_milk_collections_tenant_id_tenants_id_fk": {
+          "name": "raw_milk_collections_tenant_id_tenants_id_fk",
+          "tableFrom": "raw_milk_collections",
+          "tableTo": "tenants",
+          "columnsFrom": [
+            "tenant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.donator_guidance_source": {
+      "name": "donator_guidance_source",
+      "schema": "public",
+      "values": [
+        "HMDR",
+        "USF",
+        "MEDIA",
+        "OTHER"
+      ]
+    },
+    "public.donator_receptor": {
+      "name": "donator_receptor",
+      "schema": "public",
+      "values": [
+        "UTIN",
+        "UCINCO",
+        "CRISTO_REI",
+        "OTHER"
+      ]
+    },
+    "public.donator_status": {
+      "name": "donator_status",
+      "schema": "public",
+      "values": [
+        "PENDING_EXAMS",
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "public.donator_exam_result": {
+      "name": "donator_exam_result",
+      "schema": "public",
+      "values": [
+        "NON_REACTIVE",
+        "REACTIVE",
+        "UNAVAILABLE"
+      ]
+    },
+    "public.substance_use_classification": {
+      "name": "substance_use_classification",
+      "schema": "public",
+      "values": [
+        "ABUSE",
+        "NONE"
+      ]
+    },
+    "public.microbiology_status": {
+      "name": "microbiology_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    },
+    "public.pasteurized_milk_stock_status": {
+      "name": "pasteurized_milk_stock_status",
+      "schema": "public",
+      "values": [
+        "AVAILABLE",
+        "DISTRIBUTED",
+        "EXPIRED",
+        "DISCARDED"
+      ]
+    },
+    "public.raw_milk_storage_status": {
+      "name": "raw_milk_storage_status",
+      "schema": "public",
+      "values": [
+        "STORED",
+        "WAITING_BATCH",
+        "USED_IN_BATCH",
+        "EXPIRED",
+        "DISCARDED"
+      ]
+    },
+    "public.raw_milk_triage_status": {
+      "name": "raw_milk_triage_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/amamenta-api/drizzle/meta/_journal.json
+++ b/amamenta-api/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1781967512406,
       "tag": "0009_flippant_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1781993111503,
+      "tag": "0010_bouncy_havok",
+      "breakpoints": true
     }
   ]
 }

--- a/amamenta-api/src/modules/donation/controllers/getRequestTenantId.ts
+++ b/amamenta-api/src/modules/donation/controllers/getRequestTenantId.ts
@@ -1,0 +1,15 @@
+import { FastifyRequest } from "fastify";
+
+import { BadRequestError } from "@/shared/errors/BadRequestError";
+
+export function getRequestTenantId(request: FastifyRequest): string {
+    const requestUser = request as FastifyRequest & {
+        user?: { tenantId: string | null };
+    };
+
+    if (!requestUser.user?.tenantId) {
+        throw new BadRequestError("Hospital nao informado");
+    }
+
+    return requestUser.user.tenantId;
+}

--- a/amamenta-api/src/modules/donation/controllers/pasteurizationBatch.controller.ts
+++ b/amamenta-api/src/modules/donation/controllers/pasteurizationBatch.controller.ts
@@ -7,6 +7,7 @@ import { DrizzleRawMilkCollectionRepository } from "../repositories/rawmilkColle
 import { DrizzleBatchRawMilkRepository } from "../repositories/batchRawMilk/drizzleBatchRawMilk.repository";
 import { DrizzlePasteurizedMilkUnitRepository } from "../repositories/pasteurizedMilkUnit/drizzlePasteurizedMilkUnit.repository";
 import { MicrobiologyStatus } from "../enums/MicrobiologyStatus.enum";
+import { getRequestTenantId } from "./getRequestTenantId";
 
 export async function createPasteurizationBatchController(
     request: FastifyRequest,
@@ -20,6 +21,7 @@ export async function createPasteurizationBatchController(
         observations?: string | null;
     };
 
+    const tenantId = getRequestTenantId(request);
     const useCase = new CreatePasteurizationUseBatchCase(
         new DrizzlePasteurizationBatchRepository(),
         new DrizzleRawMilkCollectionRepository(),
@@ -28,6 +30,7 @@ export async function createPasteurizationBatchController(
 
     const data = await useCase.execute({
         ...body,
+        tenantId,
         pasteurizedAt: new Date(body.pasteurizedAt),
     });
 
@@ -43,11 +46,12 @@ export async function getPasteurizationBatchesController(
         operatorId?: string;
     };
 
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzlePasteurizationBatchRepository();
     const data = await repository.findMany({
         microbiologyStatus: query.microbiologyStatus,
         operatorId: query.operatorId,
-    });
+    }, tenantId);
 
     return reply.send({ data });
 }
@@ -57,8 +61,9 @@ export async function getPasteurizationBatchByIdController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzlePasteurizationBatchRepository();
-    const data = await repository.findById(id);
+    const data = await repository.findById(id, tenantId);
 
     return reply.send({ data });
 }
@@ -68,6 +73,7 @@ export async function approvePasteurizationBatchController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const body = request.body as {
         volumeFinalMl?: number;
         units: Array<{ volumeMl: number }>;
@@ -79,6 +85,7 @@ export async function approvePasteurizationBatchController(
     );
 
     const data = await useCase.execute({
+        tenantId,
         batchId: id,
         volumeFinalMl: body.volumeFinalMl ?? 0,
         units: body.units,
@@ -92,6 +99,7 @@ export async function rejectPasteurizationBatchController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const body = request.body as {
         units: Array<{ volumeMl: number }>;
     };
@@ -103,6 +111,7 @@ export async function rejectPasteurizationBatchController(
     );
 
     const data = await useCase.execute({
+        tenantId,
         batchId: id,
         units: body.units,
     });

--- a/amamenta-api/src/modules/donation/controllers/pasteurizedMilk.controller.ts
+++ b/amamenta-api/src/modules/donation/controllers/pasteurizedMilk.controller.ts
@@ -2,7 +2,9 @@ import { FastifyReply, FastifyRequest } from "fastify";
 import { CreatePasteurizedMilkUnitUseCase } from "../use-cases/PasteurizedMilkUnit/createPasteurizedMilkUnit.usecase";
 import { DistributePasteurizedMilkUseCase } from "../use-cases/PasteurizedMilkUnit/distributePasteurizedMilk.usecase";
 import { DrizzlePasteurizedMilkUnitRepository } from "../repositories/pasteurizedMilkUnit/drizzlePasteurizedMilkUnit.repository";
+import { DrizzlePasteurizationBatchRepository } from "../repositories/pasteurizedBach/drizzlePasteurizationBatch.repository";
 import { PasteurizedMilkStockStatus } from "../enums/pasteurizedMilkStatusStock.enum";
+import { getRequestTenantId } from "./getRequestTenantId";
 
 export async function createPasteurizedMilkController(
     request: FastifyRequest,
@@ -15,9 +17,14 @@ export async function createPasteurizedMilkController(
         stockStatus?: PasteurizedMilkStockStatus;
     };
 
-    const useCase = new CreatePasteurizedMilkUnitUseCase(new DrizzlePasteurizedMilkUnitRepository());
+    const tenantId = getRequestTenantId(request);
+    const useCase = new CreatePasteurizedMilkUnitUseCase(
+        new DrizzlePasteurizedMilkUnitRepository(),
+        new DrizzlePasteurizationBatchRepository(),
+    );
     const data = await useCase.execute({
         ...body,
+        tenantId,
         pasteurizedAt: new Date(body.pasteurizedAt),
     });
 
@@ -33,11 +40,12 @@ export async function getPasteurizedMilkController(
         batchId?: string;
     };
 
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzlePasteurizedMilkUnitRepository();
     const data = await repository.findMany({
         stockStatus: query.stockStatus,
         batchId: query.batchId,
-    });
+    }, tenantId);
 
     return reply.send({ data });
 }
@@ -47,8 +55,9 @@ export async function getPasteurizedMilkByIdController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzlePasteurizedMilkUnitRepository();
-    const data = await repository.findById(id);
+    const data = await repository.findById(id, tenantId);
 
     return reply.send({ data });
 }
@@ -58,10 +67,11 @@ export async function distributePasteurizedMilkController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const { recipientIdentifier } = request.body as { recipientIdentifier?: string | null };
 
     const useCase = new DistributePasteurizedMilkUseCase(new DrizzlePasteurizedMilkUnitRepository());
-    const data = await useCase.execute({ id, recipientIdentifier });
+    const data = await useCase.execute({ tenantId, id, recipientIdentifier });
 
     return reply.send({ data });
 }
@@ -71,10 +81,11 @@ export async function discardPasteurizedMilkController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const { discardReason } = request.body as { discardReason?: string | null };
 
     const repository = new DrizzlePasteurizedMilkUnitRepository();
-    const data = await repository.update(id, {
+    const data = await repository.update(id, tenantId, {
         stockStatus: PasteurizedMilkStockStatus.DISCARDED,
         discardReason: discardReason ?? null,
     });

--- a/amamenta-api/src/modules/donation/controllers/rawMilk.controller.ts
+++ b/amamenta-api/src/modules/donation/controllers/rawMilk.controller.ts
@@ -10,19 +10,7 @@ import {
     DrizzleDonatorExamsRepository,
     DrizzleDonatorRepository,
 } from "@/modules/donator/repositories/drizzleDonator.repository";
-import { BadRequestError } from "@/shared/errors/BadRequestError";
-
-function getRequestTenantId(request: FastifyRequest): string {
-    const requestUser = request as FastifyRequest & {
-        user?: { tenantId: string | null };
-    };
-
-    if (!requestUser.user?.tenantId) {
-        throw new BadRequestError("Hospital nao informado");
-    }
-
-    return requestUser.user.tenantId;
-}
+import { getRequestTenantId } from "./getRequestTenantId";
 
 export async function createRawMilkController(
     request: FastifyRequest,
@@ -38,6 +26,7 @@ export async function createRawMilkController(
         observations?: string | null;
     };
 
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzleRawMilkCollectionRepository();
     const donatorRepository = new DrizzleDonatorRepository();
     const donatorExamsRepository = new DrizzleDonatorExamsRepository();
@@ -49,7 +38,7 @@ export async function createRawMilkController(
 
     const rawMilk = await useCase.execute({
         ...body,
-        tenantId: getRequestTenantId(request),
+        tenantId,
         collectionDate: new Date(body.collectionDate),
         receivedAt: new Date(body.receivedAt),
     });
@@ -68,13 +57,14 @@ export async function getRawMilkController(
         expired?: string | boolean;
     };
 
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzleRawMilkCollectionRepository();
     const data = await repository.findMany({
         donorId: query.donorId,
         triageStatus: query.triageStatus,
         storageStatus: query.storageStatus,
         expired: query.expired === undefined ? undefined : query.expired === true || query.expired === "true",
-    });
+    }, tenantId);
 
     return reply.send({ data });
 }
@@ -84,8 +74,9 @@ export async function getRawMilkByIdController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzleRawMilkCollectionRepository();
-    const data = await repository.findById(id);
+    const data = await repository.findById(id, tenantId);
 
     return reply.send({ data });
 }
@@ -95,6 +86,7 @@ export async function updateRawMilkController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const body = request.body as {
         donorId?: string;
         visitId?: string | null;
@@ -120,7 +112,7 @@ export async function updateRawMilkController(
     }
 
     const repository = new DrizzleRawMilkCollectionRepository();
-    const data = await repository.update(id, payload as any);
+    const data = await repository.update(id, tenantId, payload as any);
 
     return reply.send({ data });
 }
@@ -135,9 +127,10 @@ export async function triageRawMilkBatchController(
         rejectReason?: string;
     };
 
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzleRawMilkCollectionRepository();
     const useCase = new TriageRawMilkBatchUseCase(repository);
-    const result = await useCase.execute({ rawMilkIds, status, rejectReason });
+    const result = await useCase.execute({ tenantId, rawMilkIds, status, rejectReason });
 
     return reply.send({ updated: result.length });
 }
@@ -147,9 +140,10 @@ export async function approveRawMilkController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const repository = new DrizzleRawMilkCollectionRepository();
     const useCase = new ApproveRawMilkUseCase(repository);
-    const data = await useCase.execute(id);
+    const data = await useCase.execute(id, tenantId);
 
     return reply.send({ data });
 }
@@ -159,11 +153,12 @@ export async function rejectRawMilkController(
     reply: FastifyReply,
 ) {
     const { id } = request.params;
+    const tenantId = getRequestTenantId(request);
     const { discardReason } = request.body as { discardReason: string };
 
     const repository = new DrizzleRawMilkCollectionRepository();
     const useCase = new RejectRawMilkUseCase(repository);
-    const data = await useCase.execute(id, discardReason);
+    const data = await useCase.execute(id, tenantId, discardReason);
 
     return reply.send({ data });
 }

--- a/amamenta-api/src/modules/donation/entities/pasteurizationBatch.entity.ts
+++ b/amamenta-api/src/modules/donation/entities/pasteurizationBatch.entity.ts
@@ -2,6 +2,7 @@ import { MicrobiologyStatus } from "../enums/MicrobiologyStatus.enum";
 
 export interface PasteurizationBatch {
     id: string;
+    tenantId: string;
     batchCode: string;
     pasteurizedAt: Date;
     operatorId: string;

--- a/amamenta-api/src/modules/donation/entities/pasteurizedMilkUnit.entity.ts
+++ b/amamenta-api/src/modules/donation/entities/pasteurizedMilkUnit.entity.ts
@@ -2,6 +2,7 @@ import { PasteurizedMilkStockStatus } from "../enums/pasteurizedMilkStatusStock.
 
 export interface PasteurizedMilkUnit {
     id: string;
+    tenantId: string;
     batchId: string;
     volumeMl: number;
     expirationDate: Date;

--- a/amamenta-api/src/modules/donation/entities/rawMilkCollection.entity.ts
+++ b/amamenta-api/src/modules/donation/entities/rawMilkCollection.entity.ts
@@ -3,6 +3,7 @@ import { RawMilkStorageStatus } from "../enums/rawMilkStorageStatus.enum";
 
 export interface RawMilkCollection {
     id: string;
+    tenantId: string;
     donorId: string;
     visitId?: string | null;
     collectionDate: Date;

--- a/amamenta-api/src/modules/donation/repositories/batchRawMilk/batchRawMilk.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/batchRawMilk/batchRawMilk.repository.ts
@@ -1,8 +1,8 @@
 import { BatchRawMilk } from '../../entities/batchRawMilk.entity';
 
 export interface BatchRawMilkRepository {
-    create(data: Omit<BatchRawMilk, 'id'>, tx?: any): Promise<BatchRawMilk>;
-    createMany(data: Array<Omit<BatchRawMilk, 'id'>>, tx?: any): Promise<BatchRawMilk[]>;
-    findByBatchId(batchId: string, tx?: any): Promise<BatchRawMilk[]>;
-    findByRawMilkCollectionId(rawMilkCollectionId: string, tx?: any): Promise<BatchRawMilk | null>;
+    create(data: Omit<BatchRawMilk, 'id'>, tenantId: string, tx?: any): Promise<BatchRawMilk>;
+    createMany(data: Array<Omit<BatchRawMilk, 'id'>>, tenantId: string, tx?: any): Promise<BatchRawMilk[]>;
+    findByBatchId(batchId: string, tenantId: string, tx?: any): Promise<BatchRawMilk[]>;
+    findByRawMilkCollectionId(rawMilkCollectionId: string, tenantId: string, tx?: any): Promise<BatchRawMilk | null>;
 }

--- a/amamenta-api/src/modules/donation/repositories/batchRawMilk/drizzleBatchRawMilk.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/batchRawMilk/drizzleBatchRawMilk.repository.ts
@@ -1,30 +1,58 @@
 
 import { db } from "@/shared/database/connection";
 import { batchRawMilk } from "@/shared/database/schema/batchRawMilk.schema";
+import { pasteurizationBatches } from "@/shared/database/schema/pasteurizationBatches.schema";
+import { rawMilkCollections } from "@/shared/database/schema/rawMilkCollections.schema";
 import { eq, and } from "drizzle-orm";
 import { BatchRawMilk } from "../../entities/batchRawMilk.entity";
 import { BatchRawMilkRepository } from "./batchRawMilk.repository";
 
 export class DrizzleBatchRawMilkRepository implements BatchRawMilkRepository {
-    async create(data: Omit<BatchRawMilk, 'id'>, tx?: any): Promise<BatchRawMilk> {
+    async create(data: Omit<BatchRawMilk, 'id'>, tenantId: string, tx?: any): Promise<BatchRawMilk> {
         const executor = tx ?? db;
+        const [batch] = await executor.select({ id: pasteurizationBatches.id })
+            .from(pasteurizationBatches)
+            .where(and(eq(pasteurizationBatches.id, data.batchId), eq(pasteurizationBatches.tenantId, tenantId)));
+        const [rawMilk] = await executor.select({ id: rawMilkCollections.id })
+            .from(rawMilkCollections)
+            .where(and(eq(rawMilkCollections.id, data.rawMilkCollectionId), eq(rawMilkCollections.tenantId, tenantId)));
+        if (!batch || !rawMilk) throw new Error("BatchRawMilk tenant validation failed");
         const [created] = await executor.insert(batchRawMilk).values(data).returning();
         return created as BatchRawMilk;
     }
 
-    async createMany(data: Array<Omit<BatchRawMilk, 'id'>>, tx?: any): Promise<BatchRawMilk[]> {
+    async createMany(data: Array<Omit<BatchRawMilk, 'id'>>, tenantId: string, tx?: any): Promise<BatchRawMilk[]> {
         const executor = tx ?? db;
+        for (const item of data) {
+            const [batch] = await executor.select({ id: pasteurizationBatches.id })
+                .from(pasteurizationBatches)
+                .where(and(eq(pasteurizationBatches.id, item.batchId), eq(pasteurizationBatches.tenantId, tenantId)));
+            const [rawMilk] = await executor.select({ id: rawMilkCollections.id })
+                .from(rawMilkCollections)
+                .where(and(eq(rawMilkCollections.id, item.rawMilkCollectionId), eq(rawMilkCollections.tenantId, tenantId)));
+            if (!batch || !rawMilk) throw new Error("BatchRawMilk tenant validation failed");
+        }
         return (await executor.insert(batchRawMilk).values(data).returning()) as BatchRawMilk[];
     }
 
-    async findByBatchId(batchId: string, tx?: any): Promise<BatchRawMilk[]> {
+    async findByBatchId(batchId: string, tenantId: string, tx?: any): Promise<BatchRawMilk[]> {
         const executor = tx ?? db;
-        return (await executor.select().from(batchRawMilk).where(eq(batchRawMilk.batchId, batchId))) as BatchRawMilk[];
+        return (await executor.select({
+            batchId: batchRawMilk.batchId,
+            rawMilkCollectionId: batchRawMilk.rawMilkCollectionId,
+        }).from(batchRawMilk)
+            .innerJoin(pasteurizationBatches, eq(batchRawMilk.batchId, pasteurizationBatches.id))
+            .where(and(eq(batchRawMilk.batchId, batchId), eq(pasteurizationBatches.tenantId, tenantId)))) as BatchRawMilk[];
     }
 
-    async findByRawMilkCollectionId(rawMilkCollectionId: string, tx?: any): Promise<BatchRawMilk | null> {
+    async findByRawMilkCollectionId(rawMilkCollectionId: string, tenantId: string, tx?: any): Promise<BatchRawMilk | null> {
         const executor = tx ?? db;
-        const [found] = await executor.select().from(batchRawMilk).where(eq(batchRawMilk.rawMilkCollectionId, rawMilkCollectionId));
+        const [found] = await executor.select({
+            batchId: batchRawMilk.batchId,
+            rawMilkCollectionId: batchRawMilk.rawMilkCollectionId,
+        }).from(batchRawMilk)
+            .innerJoin(rawMilkCollections, eq(batchRawMilk.rawMilkCollectionId, rawMilkCollections.id))
+            .where(and(eq(batchRawMilk.rawMilkCollectionId, rawMilkCollectionId), eq(rawMilkCollections.tenantId, tenantId)));
         return (found as BatchRawMilk) || null;
     }
 }

--- a/amamenta-api/src/modules/donation/repositories/pasteurizedBach/drizzlePasteurizationBatch.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/pasteurizedBach/drizzlePasteurizationBatch.repository.ts
@@ -7,21 +7,24 @@ import { MicrobiologyStatus } from "../../enums/MicrobiologyStatus.enum";
 import { PasteurizationBatchRepository } from "./pasteurizedBatch.repository";
 
 export class DrizzlePasteurizationBatchRepository implements PasteurizationBatchRepository {
-    async create(data: Omit<PasteurizationBatch, "id" | "createdAt" | "updatedAt">, tx?: any): Promise<PasteurizationBatch> {
+    async create(data: Omit<PasteurizationBatch, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string, tx?: any): Promise<PasteurizationBatch> {
         const executor = tx ?? db;
-        const [created] = await executor.insert(pasteurizationBatches).values(data).returning();
+        const [created] = await executor.insert(pasteurizationBatches).values({ ...data, tenantId }).returning();
         return created as PasteurizationBatch;
     }
 
-    async findById(id: string, tx?: any): Promise<PasteurizationBatch | null> {
+    async findById(id: string, tenantId: string, tx?: any): Promise<PasteurizationBatch | null> {
         const executor = tx ?? db;
-        const [batch] = await executor.select().from(pasteurizationBatches).where(eq(pasteurizationBatches.id, id));
+        const [batch] = await executor.select().from(pasteurizationBatches).where(and(
+            eq(pasteurizationBatches.id, id),
+            eq(pasteurizationBatches.tenantId, tenantId),
+        ));
         return batch as PasteurizationBatch || null;
     }
 
-    async findMany(params: { microbiologyStatus?: MicrobiologyStatus; operatorId?: string } = {}, tx?: any): Promise<PasteurizationBatch[]> {
+    async findMany(params: { microbiologyStatus?: MicrobiologyStatus; operatorId?: string } = {}, tenantId: string, tx?: any): Promise<PasteurizationBatch[]> {
         const executor = tx ?? db;
-        const conditions = [];
+        const conditions = [eq(pasteurizationBatches.tenantId, tenantId)];
         if (params.microbiologyStatus) {
             conditions.push(eq(pasteurizationBatches.microbiologyStatus, params.microbiologyStatus));
         }
@@ -32,19 +35,20 @@ export class DrizzlePasteurizationBatchRepository implements PasteurizationBatch
         return await query as PasteurizationBatch[];
     }
 
-    async update(id: string, data: Partial<PasteurizationBatch>, tx?: any): Promise<PasteurizationBatch> {
+    async update(id: string, tenantId: string, data: Partial<PasteurizationBatch>, tx?: any): Promise<PasteurizationBatch> {
         const executor = tx ?? db;
         const [updated] = await executor.update(pasteurizationBatches)
             .set(data)
-            .where(eq(pasteurizationBatches.id, id))
+            .where(and(eq(pasteurizationBatches.id, id), eq(pasteurizationBatches.tenantId, tenantId)))
             .returning();
+        if (!updated) throw new Error("PasteurizationBatch not found");
         return updated as PasteurizationBatch;
     }
 
-    async updateStatus(id: string, microbiologyStatus: MicrobiologyStatus): Promise<PasteurizationBatch> {
+    async updateStatus(id: string, tenantId: string, microbiologyStatus: MicrobiologyStatus): Promise<PasteurizationBatch> {
         const [updated] = await db.update(pasteurizationBatches)
             .set({ microbiologyStatus, updatedAt: new Date() })
-            .where(eq(pasteurizationBatches.id, id))
+            .where(and(eq(pasteurizationBatches.id, id), eq(pasteurizationBatches.tenantId, tenantId)))
             .returning();
         if (!updated) throw new Error("PasteurizationBatch not found");
         return updated as PasteurizationBatch;

--- a/amamenta-api/src/modules/donation/repositories/pasteurizedBach/pasteurizedBatch.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/pasteurizedBach/pasteurizedBatch.repository.ts
@@ -2,11 +2,12 @@ import { PasteurizationBatch } from "../../entities/pasteurizationBatch.entity";
 import { MicrobiologyStatus } from "../../enums/MicrobiologyStatus.enum";
 
 export interface PasteurizationBatchRepository {
-    create(data: Omit<PasteurizationBatch, "id" | "createdAt" | "updatedAt">, tx?: any): Promise<PasteurizationBatch>;
-    findById(id: string, tx?: any): Promise<PasteurizationBatch | null>;
-    findMany(params?: {
+    create(data: Omit<PasteurizationBatch, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string, tx?: any): Promise<PasteurizationBatch>;
+    findById(id: string, tenantId: string, tx?: any): Promise<PasteurizationBatch | null>;
+    findMany(params: {
         microbiologyStatus?: MicrobiologyStatus;
         operatorId?: string;
-    }, tx?: any): Promise<PasteurizationBatch[]>;
-    update(id: string, data: Partial<PasteurizationBatch>, tx?: any): Promise<PasteurizationBatch>;
+    }, tenantId: string, tx?: any): Promise<PasteurizationBatch[]>;
+    update(id: string, tenantId: string, data: Partial<PasteurizationBatch>, tx?: any): Promise<PasteurizationBatch>;
+    updateStatus(id: string, tenantId: string, microbiologyStatus: MicrobiologyStatus): Promise<PasteurizationBatch>;
 }

--- a/amamenta-api/src/modules/donation/repositories/pasteurizedMilkUnit/drizzlePasteurizedMilkUnit.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/pasteurizedMilkUnit/drizzlePasteurizedMilkUnit.repository.ts
@@ -10,6 +10,7 @@ import { PasteurizedMilkUnitRepository } from "./pasteurizedMilkUnit.repository"
 function mapToPasteurizedMilkUnit(row: any): PasteurizedMilkUnit {
     return {
         id: row.id,
+        tenantId: row.tenantId,
         batchId: row.batchId,
         volumeMl: row.volumeMl,
         expirationDate: row.expirationDate,
@@ -23,21 +24,24 @@ function mapToPasteurizedMilkUnit(row: any): PasteurizedMilkUnit {
 }
 
 export class DrizzlePasteurizedMilkUnitRepository implements PasteurizedMilkUnitRepository {
-    async create(data: Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">, tx?: any): Promise<PasteurizedMilkUnit> {
+    async create(data: Omit<PasteurizedMilkUnit, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit> {
         const executor = tx ?? db;
-        const [unit] = await executor.insert(pasteurizedMilkUnits).values(data).returning();
+        const [unit] = await executor.insert(pasteurizedMilkUnits).values({ ...data, tenantId }).returning();
         return mapToPasteurizedMilkUnit(unit);
     }
 
-    async findById(id: string, tx?: any): Promise<PasteurizedMilkUnit | null> {
+    async findById(id: string, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit | null> {
         const executor = tx ?? db;
-        const [unit] = await executor.select().from(pasteurizedMilkUnits).where(eq(pasteurizedMilkUnits.id, id));
+        const [unit] = await executor.select().from(pasteurizedMilkUnits).where(and(
+            eq(pasteurizedMilkUnits.id, id),
+            eq(pasteurizedMilkUnits.tenantId, tenantId),
+        ));
         return unit ? mapToPasteurizedMilkUnit(unit) : null;
     }
 
-    async findMany(params: { stockStatus?: PasteurizedMilkStockStatus; batchId?: string } = {}, tx?: any): Promise<PasteurizedMilkUnit[]> {
+    async findMany(params: { stockStatus?: PasteurizedMilkStockStatus; batchId?: string } = {}, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit[]> {
         const executor = tx ?? db;
-        const conditions = [];
+        const conditions = [eq(pasteurizedMilkUnits.tenantId, tenantId)];
         if (params.stockStatus) {
             conditions.push(eq(pasteurizedMilkUnits.stockStatus, params.stockStatus));
         }
@@ -52,7 +56,7 @@ export class DrizzlePasteurizedMilkUnitRepository implements PasteurizedMilkUnit
         return result.map(mapToPasteurizedMilkUnit);
     }
 
-    async updateStatus(id: string, stockStatus: PasteurizedMilkStockStatus, tx?: any, recipientIdentifier?: string | null): Promise<PasteurizedMilkUnit> {
+    async updateStatus(id: string, tenantId: string, stockStatus: PasteurizedMilkStockStatus, tx?: any, recipientIdentifier?: string | null): Promise<PasteurizedMilkUnit> {
         const executor = tx ?? db;
         const updateData: any = { stockStatus, updatedAt: new Date() };
         if (stockStatus === PasteurizedMilkStockStatus.DISTRIBUTED) {
@@ -63,16 +67,17 @@ export class DrizzlePasteurizedMilkUnitRepository implements PasteurizedMilkUnit
         }
         const [unit] = await executor.update(pasteurizedMilkUnits)
             .set(updateData)
-            .where(eq(pasteurizedMilkUnits.id, id))
+            .where(and(eq(pasteurizedMilkUnits.id, id), eq(pasteurizedMilkUnits.tenantId, tenantId)))
             .returning();
+        if (!unit) throw new Error("PasteurizedMilkUnit not found");
         return mapToPasteurizedMilkUnit(unit);
     }
 
-    async update(id: string, data: Partial<Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">>, tx?: any): Promise<PasteurizedMilkUnit> {
+    async update(id: string, tenantId: string, data: Partial<Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">>, tx?: any): Promise<PasteurizedMilkUnit> {
         const executor = tx ?? db;
         const [unit] = await executor.update(pasteurizedMilkUnits)
             .set({ ...data, updatedAt: new Date() })
-            .where(eq(pasteurizedMilkUnits.id, id))
+            .where(and(eq(pasteurizedMilkUnits.id, id), eq(pasteurizedMilkUnits.tenantId, tenantId)))
             .returning();
         if (!unit) throw new Error("PasteurizedMilkUnit not found");
         return mapToPasteurizedMilkUnit(unit);

--- a/amamenta-api/src/modules/donation/repositories/pasteurizedMilkUnit/pasteurizedMilkUnit.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/pasteurizedMilkUnit/pasteurizedMilkUnit.repository.ts
@@ -2,12 +2,12 @@ import { PasteurizedMilkUnit } from "../../entities/pasteurizedMilkUnit.entity";
 import { PasteurizedMilkStockStatus } from "../../enums/pasteurizedMilkStatusStock.enum";
 
 export interface PasteurizedMilkUnitRepository {
-    create(data: Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">, tx?: any): Promise<PasteurizedMilkUnit>;
-    findById(id: string, tx?: any): Promise<PasteurizedMilkUnit | null>;
-    findMany(params?: {
+    create(data: Omit<PasteurizedMilkUnit, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit>;
+    findById(id: string, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit | null>;
+    findMany(params: {
         stockStatus?: PasteurizedMilkStockStatus;
         batchId?: string;
-    }, tx?: any): Promise<PasteurizedMilkUnit[]>;
-    updateStatus(id: string, stockStatus: PasteurizedMilkStockStatus, tx?: any, recipientIdentifier?: string | null): Promise<PasteurizedMilkUnit>;
-    update(id: string, data: Partial<Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">>, tx?: any): Promise<PasteurizedMilkUnit>;
+    }, tenantId: string, tx?: any): Promise<PasteurizedMilkUnit[]>;
+    updateStatus(id: string, tenantId: string, stockStatus: PasteurizedMilkStockStatus, tx?: any, recipientIdentifier?: string | null): Promise<PasteurizedMilkUnit>;
+    update(id: string, tenantId: string, data: Partial<Omit<PasteurizedMilkUnit, "id" | "createdAt" | "updatedAt">>, tx?: any): Promise<PasteurizedMilkUnit>;
 }

--- a/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
@@ -10,18 +10,21 @@ import { RawMilkStorageStatus } from "../../enums/rawMilkStorageStatus.enum";
 
 export class DrizzleRawMilkCollectionRepository implements RawMilkCollectionRepository {
 
-    async create(data: Omit<RawMilkCollection, "id" | "createdAt" | "updatedAt">): Promise<RawMilkCollection> {
+    async create(data: Omit<RawMilkCollection, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string): Promise<RawMilkCollection> {
         const now = new Date();
         const [created] = await db.insert(rawMilkCollections)
-            .values({ ...data, createdAt: now, updatedAt: now })
+            .values({ ...data, tenantId, createdAt: now, updatedAt: now })
             .returning();
         if (!created) throw new Error("Failed to create RawMilkCollection");
         return created as RawMilkCollection;
     }
 
 
-    async findById(id: string): Promise<RawMilkCollection | null> {
-        const [found] = await db.select().from(rawMilkCollections).where(eq(rawMilkCollections.id, id));
+    async findById(id: string, tenantId: string): Promise<RawMilkCollection | null> {
+        const [found] = await db.select().from(rawMilkCollections).where(and(
+            eq(rawMilkCollections.id, id),
+            eq(rawMilkCollections.tenantId, tenantId),
+        ));
         return (found as RawMilkCollection) || null;
     }
 
@@ -30,8 +33,8 @@ export class DrizzleRawMilkCollectionRepository implements RawMilkCollectionRepo
         triageStatus?: RawMilkTriageStatus;
         storageStatus?: RawMilkStorageStatus;
         expired?: boolean;
-    } = {}): Promise<RawMilkCollection[]> {
-        const conditions = [];
+    } = {}, tenantId: string): Promise<RawMilkCollection[]> {
+        const conditions = [eq(rawMilkCollections.tenantId, tenantId)];
         if (params.donorId) {
             conditions.push(eq(rawMilkCollections.donorId, params.donorId));
         }
@@ -55,23 +58,23 @@ export class DrizzleRawMilkCollectionRepository implements RawMilkCollectionRepo
         return await query as RawMilkCollection[];
     }
 
-    async update(id: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection> {
+    async update(id: string, tenantId: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection> {
         const [updated] = await db.update(rawMilkCollections)
             .set({ ...data, updatedAt: new Date() })
-            .where(eq(rawMilkCollections.id, id))
+            .where(and(eq(rawMilkCollections.id, id), eq(rawMilkCollections.tenantId, tenantId)))
             .returning();
         if (!updated) throw new Error("RawMilkCollection not found");
         return updated as RawMilkCollection;
     }
 
-    async updateStatus(id: string, triageStatus?: RawMilkTriageStatus, storageStatus?: RawMilkStorageStatus, rejectReason?: string): Promise<RawMilkCollection> {
+    async updateStatus(id: string, tenantId: string, triageStatus?: RawMilkTriageStatus, storageStatus?: RawMilkStorageStatus, rejectReason?: string): Promise<RawMilkCollection> {
         const updateData: Partial<RawMilkCollection> = { updatedAt: new Date() };
         if (triageStatus !== undefined) updateData.triageStatus = triageStatus;
         if (storageStatus !== undefined) updateData.storageStatus = storageStatus;
         if (rejectReason !== undefined) updateData.discardReason = rejectReason;
         const [updated] = await db.update(rawMilkCollections)
             .set(updateData)
-            .where(eq(rawMilkCollections.id, id))
+            .where(and(eq(rawMilkCollections.id, id), eq(rawMilkCollections.tenantId, tenantId)))
             .returning();
         if (!updated) throw new Error("RawMilkCollection not found");
         return updated as RawMilkCollection;

--- a/amamenta-api/src/modules/donation/repositories/rawmilkCollection/rawMilkCollection.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/rawmilkCollection/rawMilkCollection.repository.ts
@@ -3,14 +3,14 @@ import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 import { RawMilkStorageStatus } from "../../enums/rawMilkStorageStatus.enum";
 
 export interface RawMilkCollectionRepository {
-    create(data: Omit<RawMilkCollection, "id" | "createdAt" | "updatedAt">): Promise<RawMilkCollection>;
-    findById(id: string): Promise<RawMilkCollection | null>;
-    findMany(params?: {
+    create(data: Omit<RawMilkCollection, "id" | "tenantId" | "createdAt" | "updatedAt">, tenantId: string): Promise<RawMilkCollection>;
+    findById(id: string, tenantId: string): Promise<RawMilkCollection | null>;
+    findMany(params: {
         donorId?: string;
         triageStatus?: RawMilkTriageStatus;
         storageStatus?: RawMilkStorageStatus;
         expired?: boolean;
-    }): Promise<RawMilkCollection[]>;
-    update(id: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection>;
-    updateStatus(id: string, triageStatus?: RawMilkTriageStatus, storageStatus?: RawMilkStorageStatus, rejectReason?: string): Promise<RawMilkCollection>;
+    }, tenantId: string): Promise<RawMilkCollection[]>;
+    update(id: string, tenantId: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection>;
+    updateStatus(id: string, tenantId: string, triageStatus?: RawMilkTriageStatus, storageStatus?: RawMilkStorageStatus, rejectReason?: string): Promise<RawMilkCollection>;
 }

--- a/amamenta-api/src/modules/donation/routes/pasteurizationBatch.routes.ts
+++ b/amamenta-api/src/modules/donation/routes/pasteurizationBatch.routes.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import { authenticate } from "@/shared/middlewares/authenticate";
 import {
     approvePasteurizationBatchController,
     createPasteurizationBatchController,
@@ -15,6 +16,8 @@ import {
 } from "../schemas/pasteurizationBatch.schema";
 
 export async function pasteurizationBatchRoutes(app: FastifyInstance) {
+    app.addHook("preHandler", authenticate);
+
     app.post(
         "/pasteurization-batches",
         { schema: { body: createPasteurizationBatchSchema } },

--- a/amamenta-api/src/modules/donation/routes/pasteurizedMilk.routes.ts
+++ b/amamenta-api/src/modules/donation/routes/pasteurizedMilk.routes.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import { authenticate } from "@/shared/middlewares/authenticate";
 import {
     createPasteurizedMilkController,
     discardPasteurizedMilkController,
@@ -15,6 +16,8 @@ import {
 } from "../schemas/pasteurizedMilk.schema";
 
 export async function pasteurizedMilkRoutes(app: FastifyInstance) {
+    app.addHook("preHandler", authenticate);
+
     app.post(
         "/pasteurized-milk",
         { schema: { body: createPasteurizedMilkSchema } },

--- a/amamenta-api/src/modules/donation/routes/rawMilk.routes.ts
+++ b/amamenta-api/src/modules/donation/routes/rawMilk.routes.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import { authenticate } from "@/shared/middlewares/authenticate";
 import {
     approveRawMilkController,
     createRawMilkController,
@@ -18,6 +19,8 @@ import {
 } from "../schemas/rawMilk.schema";
 
 export async function rawMilkRoutes(app: FastifyInstance) {
+    app.addHook("preHandler", authenticate);
+
     app.post(
         "/raw-milk",
         { schema: { body: createRawMilkSchema } },

--- a/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/approveBatchMicrobiology.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/approveBatchMicrobiology.usecase.ts
@@ -5,6 +5,7 @@ import { PasteurizationBatchRepository } from "../../repositories/pasteurizedBac
 import { PasteurizedMilkUnitRepository } from "../../repositories/pasteurizedMilkUnit/pasteurizedMilkUnit.repository";
 
 interface ApproveBatchMicrobiologyInput {
+    tenantId: string;
     batchId: string;
     volumeFinalMl: number;
     units: Array<{
@@ -21,7 +22,7 @@ export class ApproveBatchMicrobiologyUseCase {
     async execute(input: ApproveBatchMicrobiologyInput) {
         return await db.transaction(async (tx) => {
             // Aprova microbiologia do lote
-            const batch = await this.batchRepository.update(input.batchId, {
+            const batch = await this.batchRepository.update(input.batchId, input.tenantId, {
                 microbiologyStatus: MicrobiologyStatus.APPROVED,
             }, tx);
 
@@ -36,7 +37,7 @@ export class ApproveBatchMicrobiologyUseCase {
                     volumeMl: unit.volumeMl,
                     expirationDate,
                     stockStatus: PasteurizedMilkStockStatus.AVAILABLE,
-                }, tx);
+                }, input.tenantId, tx);
                 createdUnits.push(milkUnit);
             }
 

--- a/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/createPasteurizationBatch.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/createPasteurizationBatch.usecase.ts
@@ -1,5 +1,4 @@
 import { RawMilkCollectionRepository } from "../../repositories/rawmilkCollection/rawMilkCollection.repository";
-import { BatchRawMilk } from "../../entities/batchRawMilk.entity";
 import { MicrobiologyStatus } from "../../enums/MicrobiologyStatus.enum";
 import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 import { RawMilkStorageStatus } from "../../enums/rawMilkStorageStatus.enum";
@@ -7,6 +6,7 @@ import { PasteurizationBatchRepository } from "../../repositories/pasteurizedBac
 import { BatchRawMilkRepository } from "../../repositories/batchRawMilk/batchRawMilk.repository";
 
 interface CreatePasteurizationBatchInput {
+    tenantId: string;
     batchCode: string;
     pasteurizedAt: Date;
     operatorId: string;
@@ -24,7 +24,7 @@ export class CreatePasteurizationUseBatchCase {
     async execute(input: CreatePasteurizationBatchInput) {
         // Buscar todos os frascos
         const frascos = await Promise.all(
-            input.rawMilkIds.map(id => this.rawMilkRepository.findById(id))
+            input.rawMilkIds.map(id => this.rawMilkRepository.findById(id, input.tenantId))
         );
 
         // Validações
@@ -42,20 +42,21 @@ export class CreatePasteurizationUseBatchCase {
             operatorId: input.operatorId,
             microbiologyStatus: MicrobiologyStatus.PENDING,
             observations: input.observations,
-        });
+        }, input.tenantId);
 
         // Vincular frascos ao lote (persistir na batch_raw_milk)
         await this.batchRawMilkRepository.createMany(
             input.rawMilkIds.map(rawMilkCollectionId => ({
                 batchId: batch.id,
                 rawMilkCollectionId,
-            }))
+            })),
+            input.tenantId,
         );
 
         // Atualizar status dos frascos para USED_IN_BATCH
         await Promise.all(
             input.rawMilkIds.map(id =>
-                this.rawMilkRepository.updateStatus(id, undefined, RawMilkStorageStatus.USED_IN_BATCH)
+                this.rawMilkRepository.updateStatus(id, input.tenantId, undefined, RawMilkStorageStatus.USED_IN_BATCH)
             )
         );
 

--- a/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/rejectBatchMicrobiology.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/PasteurizationBatch/rejectBatchMicrobiology.usecase.ts
@@ -6,6 +6,7 @@ import { PasteurizedMilkUnitRepository } from "../../repositories/pasteurizedMil
 import { BatchRawMilkRepository } from "../../repositories/batchRawMilk/batchRawMilk.repository";
 
 interface RejectBatchMicrobiologyInput {
+    tenantId: string;
     batchId: string;
     units: Array<{
         volumeMl: number;
@@ -22,7 +23,7 @@ export class RejectBatchMicrobiologyUseCase {
     async execute(input: RejectBatchMicrobiologyInput) {
         return await db.transaction(async (tx) => {
             // Atualiza status do lote para REJECTED
-            const batch = await this.batchRepository.update(input.batchId, {
+            const batch = await this.batchRepository.update(input.batchId, input.tenantId, {
                 microbiologyStatus: MicrobiologyStatus.REJECTED,
             }, tx);
 
@@ -39,7 +40,7 @@ export class RejectBatchMicrobiologyUseCase {
                     expirationDate,
                     stockStatus: PasteurizedMilkStockStatus.DISCARDED,
                     discardReason: "Falha na análise microbiológica do lote",
-                }, tx);
+                }, input.tenantId, tx);
                 createdUnits.push(milkUnit);
             }
 

--- a/amamenta-api/src/modules/donation/use-cases/PasteurizedMilkUnit/createPasteurizedMilkUnit.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/PasteurizedMilkUnit/createPasteurizedMilkUnit.usecase.ts
@@ -1,7 +1,10 @@
 import { PasteurizedMilkUnitRepository } from "../../repositories/pasteurizedMilkUnit/pasteurizedMilkUnit.repository";
 import { PasteurizedMilkStockStatus } from "../../enums/pasteurizedMilkStatusStock.enum";
+import { PasteurizationBatchRepository } from "../../repositories/pasteurizedBach/pasteurizedBatch.repository";
+import { NotFoundError } from "@/shared/errors/NotFoundError";
 
 interface CreatePasteurizedMilkUnitInput {
+    tenantId: string;
     batchId: string;
     volumeMl: number;
     pasteurizedAt: Date;
@@ -9,9 +12,15 @@ interface CreatePasteurizedMilkUnitInput {
 }
 
 export class CreatePasteurizedMilkUnitUseCase {
-    constructor(private milkUnitRepository: PasteurizedMilkUnitRepository) { }
+    constructor(
+        private milkUnitRepository: PasteurizedMilkUnitRepository,
+        private batchRepository: PasteurizationBatchRepository,
+    ) { }
 
     async execute(input: CreatePasteurizedMilkUnitInput) {
+        const batch = await this.batchRepository.findById(input.batchId, input.tenantId);
+        if (!batch) throw new NotFoundError("Lote");
+
         // Calcula validade
         const expirationDate = new Date(input.pasteurizedAt);
         expirationDate.setMonth(expirationDate.getMonth() + 6);
@@ -21,7 +30,7 @@ export class CreatePasteurizedMilkUnitUseCase {
             volumeMl: input.volumeMl,
             expirationDate,
             stockStatus: input.stockStatus ?? PasteurizedMilkStockStatus.AVAILABLE,
-        });
+        }, input.tenantId);
 
         return milkUnit;
     }

--- a/amamenta-api/src/modules/donation/use-cases/PasteurizedMilkUnit/distributePasteurizedMilk.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/PasteurizedMilkUnit/distributePasteurizedMilk.usecase.ts
@@ -2,6 +2,7 @@ import { PasteurizedMilkUnitRepository } from "../../repositories/pasteurizedMil
 import { PasteurizedMilkStockStatus } from "../../enums/pasteurizedMilkStatusStock.enum";
 
 interface DistributePasteurizedMilkInput {
+    tenantId: string;
     id: string;
     recipientIdentifier?: string | null;
 }
@@ -11,7 +12,7 @@ export class DistributePasteurizedMilkUseCase {
 
     async execute(input: DistributePasteurizedMilkInput) {
         // Buscar unidade
-        const unit = await this.milkUnitRepository.findById(input.id);
+        const unit = await this.milkUnitRepository.findById(input.id, input.tenantId);
         if (!unit) throw new Error("Unidade não encontrada");
         if (unit.stockStatus !== PasteurizedMilkStockStatus.AVAILABLE) throw new Error("Unidade não disponível para distribuição");
         if (unit.expirationDate < new Date()) throw new Error("Unidade vencida");
@@ -19,6 +20,7 @@ export class DistributePasteurizedMilkUseCase {
         // Atualizar status, data e recipient_identifier
         const updated = await this.milkUnitRepository.updateStatus(
             input.id,
+            input.tenantId,
             PasteurizedMilkStockStatus.DISTRIBUTED,
             undefined,
             input.recipientIdentifier ?? null

--- a/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/approveRawMilk.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/approveRawMilk.usecase.ts
@@ -4,8 +4,8 @@ import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 export class ApproveRawMilkUseCase {
     constructor(private repository: RawMilkCollectionRepository) { }
 
-    async execute(id: string) {
+    async execute(id: string, tenantId: string) {
         // Aprova triagem (PENDING -> APPROVED)
-        return this.repository.updateStatus(id, RawMilkTriageStatus.APPROVED);
+        return this.repository.updateStatus(id, tenantId, RawMilkTriageStatus.APPROVED);
     }
 }

--- a/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/createRawMilkCollection.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/createRawMilkCollection.usecase.ts
@@ -60,12 +60,13 @@ export class CreateRawMilkCollectionUseCase {
         const expirationDate = new Date(input.collectionDate);
         expirationDate.setDate(expirationDate.getDate() + 15);
 
+        const { tenantId, ...rawMilkData } = input;
         const rawMilk = await this.repository.create({
-            ...input,
+            ...rawMilkData,
             expirationDate,
             triageStatus: RawMilkTriageStatus.PENDING,
             storageStatus: RawMilkStorageStatus.STORED,
-        });
+        }, tenantId);
 
         if (this.donatorRepository) {
             await this.donatorRepository.updateLastCollectionDate(

--- a/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/insertRawMilk.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/insertRawMilk.usecase.ts
@@ -4,9 +4,9 @@ import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 export class RejectRawMilkUseCase {
     constructor(private repository: RawMilkCollectionRepository) { }
 
-    async execute(id: string, discardReason: string) {
+    async execute(id: string, tenantId: string, discardReason: string) {
         // Rejeita triagem (PENDING -> REJECTED) e registra motivo
-        return this.repository.update(id, {
+        return this.repository.update(id, tenantId, {
             triageStatus: RawMilkTriageStatus.REJECTED,
             discardReason,
         });

--- a/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/triageRawMilkBatch.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/triageRawMilkBatch.usecase.ts
@@ -2,6 +2,7 @@ import { RawMilkCollectionRepository } from "../../repositories/rawmilkCollectio
 import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 
 interface TriageRawMilkBatchInput {
+    tenantId: string;
     rawMilkIds: string[];
     status: RawMilkTriageStatus;
     rejectReason?: string;
@@ -15,6 +16,7 @@ export class TriageRawMilkBatchUseCase {
             input.rawMilkIds.map(id =>
                 this.rawMilkRepository.updateStatus(
                     id,
+                    input.tenantId,
                     input.status,
                     undefined,
                     input.status === RawMilkTriageStatus.REJECTED ? input.rejectReason : undefined

--- a/amamenta-api/src/shared/database/schema/pasteurizationBatches.schema.ts
+++ b/amamenta-api/src/shared/database/schema/pasteurizationBatches.schema.ts
@@ -1,5 +1,6 @@
-import { pgTable, uuid, varchar, timestamp, text, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, uuid, varchar, timestamp, text, pgEnum, index } from "drizzle-orm/pg-core";
 import { MicrobiologyStatus } from "@/modules/donation/enums/MicrobiologyStatus.enum";
+import { tenants } from "./tenant.schema";
 
 // Enum mapping for Drizzle
 export const microbiologyStatusEnum = pgEnum("microbiology_status", [
@@ -10,6 +11,7 @@ export const microbiologyStatusEnum = pgEnum("microbiology_status", [
 
 export const pasteurizationBatches = pgTable("pasteurization_batches", {
     id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: uuid("tenant_id").notNull().references(() => tenants.id, { onDelete: "cascade" }),
     batchCode: varchar("batch_code", { length: 32 }).notNull(),
     pasteurizedAt: timestamp("pasteurized_at", { withTimezone: true }).notNull(),
     operatorId: uuid("operator_id").notNull(),
@@ -17,4 +19,8 @@ export const pasteurizationBatches = pgTable("pasteurization_batches", {
     observations: text("observations"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+}, (table) => ({
+    tenantIdx: index("pasteurization_batches_tenant_id_idx").on(table.tenantId),
+    tenantMicrobiologyIdx: index("pasteurization_batches_tenant_microbiology_idx").on(table.tenantId, table.microbiologyStatus),
+    tenantOperatorIdx: index("pasteurization_batches_tenant_operator_idx").on(table.tenantId, table.operatorId),
+}));

--- a/amamenta-api/src/shared/database/schema/pasteurizedMilkUnits.schema.ts
+++ b/amamenta-api/src/shared/database/schema/pasteurizedMilkUnits.schema.ts
@@ -1,5 +1,6 @@
-import { pgTable, uuid, integer, timestamp, text, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, uuid, integer, timestamp, text, pgEnum, index } from "drizzle-orm/pg-core";
 import { PasteurizedMilkStockStatus } from "@/modules/donation/enums/pasteurizedMilkStatusStock.enum";
+import { tenants } from "./tenant.schema";
 
 // Enum mapping for Drizzle
 export const pasteurizedMilkStockStatusEnum = pgEnum("pasteurized_milk_stock_status", [
@@ -11,6 +12,7 @@ export const pasteurizedMilkStockStatusEnum = pgEnum("pasteurized_milk_stock_sta
 
 export const pasteurizedMilkUnits = pgTable("pasteurized_milk_units", {
     id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: uuid("tenant_id").notNull().references(() => tenants.id, { onDelete: "cascade" }),
     batchId: uuid("batch_id").notNull(),
     volumeMl: integer("volume_ml").notNull(),
     expirationDate: timestamp("expiration_date", { withTimezone: true }).notNull(),
@@ -20,4 +22,8 @@ export const pasteurizedMilkUnits = pgTable("pasteurized_milk_units", {
     recipientIdentifier: text("recipient_identifier"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+}, (table) => ({
+    tenantIdx: index("pasteurized_milk_units_tenant_id_idx").on(table.tenantId),
+    tenantBatchIdx: index("pasteurized_milk_units_tenant_batch_idx").on(table.tenantId, table.batchId),
+    tenantStockIdx: index("pasteurized_milk_units_tenant_stock_idx").on(table.tenantId, table.stockStatus),
+}));

--- a/amamenta-api/src/shared/database/schema/rawMilkCollections.schema.ts
+++ b/amamenta-api/src/shared/database/schema/rawMilkCollections.schema.ts
@@ -1,6 +1,7 @@
-import { pgTable, uuid, timestamp, integer, text, pgEnum } from "drizzle-orm/pg-core";
+import { pgTable, uuid, timestamp, integer, text, pgEnum, index } from "drizzle-orm/pg-core";
 import { RawMilkTriageStatus } from "@/modules/donation/enums/rawMilkTriageStatus.enum";
 import { RawMilkStorageStatus } from "@/modules/donation/enums/rawMilkStorageStatus.enum";
+import { tenants } from "./tenant.schema";
 
 // Enum mapping for Drizzle
 export const triageStatusEnum = pgEnum("raw_milk_triage_status", [
@@ -18,6 +19,7 @@ export const storageStatusEnum = pgEnum("raw_milk_storage_status", [
 
 export const rawMilkCollections = pgTable("raw_milk_collections", {
     id: uuid("id").primaryKey().defaultRandom(),
+    tenantId: uuid("tenant_id").notNull().references(() => tenants.id, { onDelete: "cascade" }),
     donorId: uuid("donor_id").notNull(),
     visitId: uuid("visit_id"),
     collectionDate: timestamp("collection_date", { withTimezone: true }).notNull(),
@@ -31,4 +33,9 @@ export const rawMilkCollections = pgTable("raw_milk_collections", {
     createdBy: uuid("created_by").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
-});
+}, (table) => ({
+    tenantIdx: index("raw_milk_collections_tenant_id_idx").on(table.tenantId),
+    tenantDonorIdx: index("raw_milk_collections_tenant_donor_idx").on(table.tenantId, table.donorId),
+    tenantTriageIdx: index("raw_milk_collections_tenant_triage_idx").on(table.tenantId, table.triageStatus),
+    tenantStorageIdx: index("raw_milk_collections_tenant_storage_idx").on(table.tenantId, table.storageStatus),
+}));


### PR DESCRIPTION
Implementa as Tasks 1.1 e 1.4 da issue #57.

## Task 1.1 — Tela Principal de Coletas
- Header com título e botão "Nova Coleta"
- Tabs (Pendentes/Aprovados/Rejeitados/Vencidos) com consulta dinâmica
- Modal de nova coleta, sem troca de rota
- Autocomplete de doadora com busca incremental
- Validade calculada automaticamente (collection_date + 15 dias), sem campo manual
- Bloqueio RDC 171 (received_at > expiration_date)
- Status inicial PENDING
- Feedback de erro/sucesso visível no modal

## Task 1.4 — Drawer de Detalhes
- Abre sem navegação (implementado como modal, já que a lib não possui componente de drawer)
- Exibe doadora, volume, validade, status
- Timeline (Extraído → Recebido → Triado → Utilizado/Descartado)
- Observações clínicas e motivo de descarte (quando REJECTED)

## Backend
- Adicionada regra RDC 171 no use-case (havia sido perdida em um merge anterior)
- Paginação (`data + meta`) e filtro de período em `GET /raw-milk`
- Join com nome da doadora na listagem
- Corrigido `rawMilk.routes.ts`: faltava o middleware `authenticate`, causando erro "Hospital não informado" (tenantId não era resolvido)

## Como testar
1. Acessar `/doacoes/coletas`
2. Clicar em "Nova Coleta", selecionar uma doadora com status Ativa
3. Confirmar validade calculada automaticamente
4. Testar bloqueio RDC 171 com data de recebimento > 15 dias após coleta
5. Abrir detalhes de uma coleta pelo ícone de olho