### PR TITLE
Feature/57 gestao coletas

### DIFF
--- a/amamenta-api/src/modules/donation/controllers/rawMilk.controller.ts
+++ b/amamenta-api/src/modules/donation/controllers/rawMilk.controller.ts
@@ -66,17 +66,31 @@ export async function getRawMilkController(
         triageStatus?: RawMilkTriageStatus;
         storageStatus?: RawMilkStorageStatus;
         expired?: string | boolean;
+        collectionDateFrom?: string | Date;
+        collectionDateTo?: string | Date;
+        page?: number;
+        limit?: number;
     };
 
     const repository = new DrizzleRawMilkCollectionRepository();
-    const data = await repository.findMany({
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 10;
+
+    const { data, total } = await repository.findMany({
         donorId: query.donorId,
         triageStatus: query.triageStatus,
         storageStatus: query.storageStatus,
         expired: query.expired === undefined ? undefined : query.expired === true || query.expired === "true",
+        collectionDateFrom: query.collectionDateFrom ? new Date(query.collectionDateFrom) : undefined,
+        collectionDateTo: query.collectionDateTo ? new Date(query.collectionDateTo) : undefined,
+        page,
+        limit,
     });
 
-    return reply.send({ data });
+    return reply.send({
+        data,
+        meta: { page, limit, total, totalPages: Math.ceil(total / limit) || 1 },
+    });
 }
 
 export async function getRawMilkByIdController(

--- a/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
@@ -50,7 +50,7 @@ async findById(id: string, tenantId: string): Promise<RawMilkCollection | null> 
         const limit = params.limit ?? 10;
         const offset = (page - 1) * limit;
 
-        const [data, totalResult] = await Promise.all([
+        const [data, totalResult] = await Promise.all([  
             db
                 .select({
                     id: rawMilkCollections.id,

--- a/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/rawmilkCollection/drizzleRawMilkCollection.repository.ts
@@ -1,12 +1,15 @@
-
 import { db } from "@/shared/database/connection";
 import { rawMilkCollections } from "@/shared/database/schema/rawMilkCollections.schema";
-import { eq, and, lte, gt } from "drizzle-orm";
+import { donators } from "@/shared/database/schema/donator.schema";
+import { eq, and, lte, gt, gte, sql } from "drizzle-orm";
 import { RawMilkCollection } from "../../entities/rawMilkCollection.entity";
-import { RawMilkCollectionRepository } from "./rawMilkCollection.repository";
+import {
+    RawMilkCollectionRepository,
+    RawMilkFindManyParams,
+    RawMilkFindManyResult,
+} from "./rawMilkCollection.repository";
 import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 import { RawMilkStorageStatus } from "../../enums/rawMilkStorageStatus.enum";
-
 
 export class DrizzleRawMilkCollectionRepository implements RawMilkCollectionRepository {
 
@@ -19,40 +22,63 @@ export class DrizzleRawMilkCollectionRepository implements RawMilkCollectionRepo
         return created as RawMilkCollection;
     }
 
-
     async findById(id: string): Promise<RawMilkCollection | null> {
         const [found] = await db.select().from(rawMilkCollections).where(eq(rawMilkCollections.id, id));
         return (found as RawMilkCollection) || null;
     }
 
-    async findMany(params: {
-        donorId?: string;
-        triageStatus?: RawMilkTriageStatus;
-        storageStatus?: RawMilkStorageStatus;
-        expired?: boolean;
-    } = {}): Promise<RawMilkCollection[]> {
+    async findMany(params: RawMilkFindManyParams = {}): Promise<RawMilkFindManyResult> {
         const conditions = [];
-        if (params.donorId) {
-            conditions.push(eq(rawMilkCollections.donorId, params.donorId));
-        }
-        if (params.triageStatus !== undefined) {
-            conditions.push(eq(rawMilkCollections.triageStatus, params.triageStatus));
-        }
-        if (params.storageStatus !== undefined) {
-            conditions.push(eq(rawMilkCollections.storageStatus, params.storageStatus));
-        }
+        if (params.donorId) conditions.push(eq(rawMilkCollections.donorId, params.donorId));
+        if (params.triageStatus !== undefined) conditions.push(eq(rawMilkCollections.triageStatus, params.triageStatus));
+        if (params.storageStatus !== undefined) conditions.push(eq(rawMilkCollections.storageStatus, params.storageStatus));
         if (params.expired !== undefined) {
-            if (params.expired) {
-                conditions.push(lte(rawMilkCollections.expirationDate, new Date()));
-            } else {
-                conditions.push(gt(rawMilkCollections.expirationDate, new Date()));
-            }
+            conditions.push(
+                params.expired
+                    ? lte(rawMilkCollections.expirationDate, new Date())
+                    : gt(rawMilkCollections.expirationDate, new Date()),
+            );
         }
-        const query = db
-            .select()
-            .from(rawMilkCollections)
-            .where(conditions.length ? and(...conditions) : undefined);
-        return await query as RawMilkCollection[];
+        if (params.collectionDateFrom) conditions.push(gte(rawMilkCollections.collectionDate, params.collectionDateFrom));
+        if (params.collectionDateTo) conditions.push(lte(rawMilkCollections.collectionDate, params.collectionDateTo));
+
+        const where = conditions.length ? and(...conditions) : undefined;
+        const page = params.page ?? 1;
+        const limit = params.limit ?? 10;
+        const offset = (page - 1) * limit;
+
+        const [data, totalResult] = await Promise.all([
+            db
+                .select({
+                    id: rawMilkCollections.id,
+                    donorId: rawMilkCollections.donorId,
+                    donorName: donators.name,
+                    visitId: rawMilkCollections.visitId,
+                    collectionDate: rawMilkCollections.collectionDate,
+                    receivedAt: rawMilkCollections.receivedAt,
+                    volumeMl: rawMilkCollections.volumeMl,
+                    expirationDate: rawMilkCollections.expirationDate,
+                    triageStatus: rawMilkCollections.triageStatus,
+                    storageStatus: rawMilkCollections.storageStatus,
+                    discardReason: rawMilkCollections.discardReason,
+                    observations: rawMilkCollections.observations,
+                    createdBy: rawMilkCollections.createdBy,
+                    createdAt: rawMilkCollections.createdAt,
+                    updatedAt: rawMilkCollections.updatedAt,
+                })
+                .from(rawMilkCollections)
+                .leftJoin(donators, eq(donators.id, rawMilkCollections.donorId))
+                .where(where)
+                .orderBy(sql`${rawMilkCollections.createdAt} desc`)
+                .limit(limit)
+                .offset(offset),
+            db.select({ count: sql<number>`count(*)` }).from(rawMilkCollections).where(where),
+        ]);
+
+        return {
+            data: data as (RawMilkCollection & { donorName?: string | null })[],
+            total: Number(totalResult[0]?.count ?? 0),
+        };
     }
 
     async update(id: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection> {

--- a/amamenta-api/src/modules/donation/repositories/rawmilkCollection/rawMilkCollection.repository.ts
+++ b/amamenta-api/src/modules/donation/repositories/rawmilkCollection/rawMilkCollection.repository.ts
@@ -2,15 +2,26 @@ import { RawMilkCollection } from "../../entities/rawMilkCollection.entity";
 import { RawMilkTriageStatus } from "../../enums/rawMilkTriageStatus.enum";
 import { RawMilkStorageStatus } from "../../enums/rawMilkStorageStatus.enum";
 
+export interface RawMilkFindManyParams {
+    donorId?: string;
+    triageStatus?: RawMilkTriageStatus;
+    storageStatus?: RawMilkStorageStatus;
+    expired?: boolean;
+    collectionDateFrom?: Date;
+    collectionDateTo?: Date;
+    page?: number;
+    limit?: number;
+}
+
+export interface RawMilkFindManyResult {
+    data: (RawMilkCollection & { donorName?: string | null })[];
+    total: number;
+}
+
 export interface RawMilkCollectionRepository {
     create(data: Omit<RawMilkCollection, "id" | "createdAt" | "updatedAt">): Promise<RawMilkCollection>;
     findById(id: string): Promise<RawMilkCollection | null>;
-    findMany(params?: {
-        donorId?: string;
-        triageStatus?: RawMilkTriageStatus;
-        storageStatus?: RawMilkStorageStatus;
-        expired?: boolean;
-    }): Promise<RawMilkCollection[]>;
+    findMany(params?: RawMilkFindManyParams): Promise<RawMilkFindManyResult>;
     update(id: string, data: Partial<RawMilkCollection>): Promise<RawMilkCollection>;
     updateStatus(id: string, triageStatus?: RawMilkTriageStatus, storageStatus?: RawMilkStorageStatus, rejectReason?: string): Promise<RawMilkCollection>;
 }

--- a/amamenta-api/src/modules/donation/routes/rawMilk.routes.ts
+++ b/amamenta-api/src/modules/donation/routes/rawMilk.routes.ts
@@ -1,4 +1,5 @@
 import { FastifyInstance } from "fastify";
+import { authenticate } from "@/shared/middlewares/authenticate";
 import {
     approveRawMilkController,
     createRawMilkController,
@@ -18,10 +19,13 @@ import {
 } from "../schemas/rawMilk.schema";
 
 export async function rawMilkRoutes(app: FastifyInstance) {
+     app.addHook("preHandler", authenticate);
+
     app.post(
         "/raw-milk",
         { schema: { body: createRawMilkSchema } },
         createRawMilkController,
+
     );
     app.get(
         "/raw-milk",

--- a/amamenta-api/src/modules/donation/schemas/rawMilk.schema.ts
+++ b/amamenta-api/src/modules/donation/schemas/rawMilk.schema.ts
@@ -27,10 +27,14 @@ export const triageRawMilkBatchSchema = z.object({
 });
 
 export const rawMilkQuerySchema = z.object({
+   page: z.coerce.number().min(1).default(1),
+    limit: z.coerce.number().min(1).max(50).default(10),
     donorId: z.string().uuid().optional(),
     triageStatus: z.nativeEnum(RawMilkTriageStatus).optional(),
     storageStatus: z.nativeEnum(RawMilkStorageStatus).optional(),
     expired: z.enum(["true", "false"]).transform((value) => value === "true").optional(),
+    collectionDateFrom: z.coerce.date().optional(),
+    collectionDateTo: z.coerce.date().optional(),
 });
 
 export const rejectRawMilkSchema = z.object({

--- a/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/createRawMilkCollection.usecase.ts
+++ b/amamenta-api/src/modules/donation/use-cases/rawMilkCollection/createRawMilkCollection.usecase.ts
@@ -60,6 +60,12 @@ export class CreateRawMilkCollectionUseCase {
         const expirationDate = new Date(input.collectionDate);
         expirationDate.setDate(expirationDate.getDate() + 15);
 
+        if (input.receivedAt > expirationDate) {
+            throw new BadRequestError(
+                "Frasco recebido após prazo permitido para armazenamento domiciliar.",
+            );
+        }
+
         const rawMilk = await this.repository.create({
             ...input,
             expirationDate,

--- a/amamenta-ui/package.json
+++ b/amamenta-ui/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.4",
+    "@govbr-ds/core": "^3.7.0",
     "@govbr-ds/react-components": "^2.15.1",
     "axios": "^1.16.1",
     "font-awesome": "^4.7.0",

--- a/amamenta-ui/src/pages/Default/Donations/RawMilkCollectionsPage.css
+++ b/amamenta-ui/src/pages/Default/Donations/RawMilkCollectionsPage.css
@@ -1,0 +1,110 @@
+.raw-milk-collections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 1280px;
+}
+
+.raw-milk-collections__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.raw-milk-collections__title {
+  color: var(--gray-90, #1b1b1b);
+  font-size: 28px;
+  margin: 0;
+}
+
+.raw-milk-collections__description {
+  color: var(--gray-70, #3d3d3d);
+  margin: 8px 0 0;
+}
+
+.raw-milk-collections__tabs {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid var(--gray-10, #e6e6e6);
+}
+
+.raw-milk-collections__tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--gray-70, #3d3d3d);
+  cursor: pointer;
+  padding: 10px 16px;
+}
+
+.raw-milk-collections__tab--active {
+  border-bottom-color: var(--blue-warm-vivid-70, #1351b4);
+  color: var(--blue-warm-vivid-70, #1351b4);
+  font-weight: 600;
+}
+
+.raw-milk-collections__table {
+  background: var(--pure-0, #fff);
+  border: 1px solid var(--gray-10, #e6e6e6);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.raw-milk-collections__error {
+  background: var(--red-vivid-5, #fff3f2);
+  border-left: 4px solid var(--danger, #e52207);
+  color: var(--gray-90, #1b1b1b);
+  padding: 12px 16px;
+}
+
+.raw-milk-collections__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.raw-milk-collections__autocomplete {
+  position: relative;
+}
+
+.raw-milk-collections__autocomplete-list {
+  background: var(--pure-0, #fff);
+  border: 1px solid var(--gray-10, #e6e6e6);
+  border-radius: 4px;
+  list-style: none;
+  margin: 4px 0 0;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}
+
+.raw-milk-collections__autocomplete-list li {
+  cursor: pointer;
+  padding: 8px 12px;
+}
+
+.raw-milk-collections__autocomplete-list li:hover {
+  background: var(--gray-2, #f4f4f4);
+}
+
+.raw-milk-collections__timeline {
+  list-style: none;
+  margin: 8px 0 16px;
+  padding: 0;
+}
+
+.raw-milk-collections__timeline-item {
+  border-left: 2px solid var(--gray-10, #e6e6e6);
+  color: var(--gray-50, #888);
+  padding: 6px 0 6px 16px;
+}
+
+.raw-milk-collections__timeline-item--active {
+  border-left-color: var(--blue-warm-vivid-70, #1351b4);
+  color: var(--blue-warm-vivid-70, #1351b4);
+  font-weight: 600;
+}

--- a/amamenta-ui/src/pages/Default/Donations/RawMilkCollectionsPage.tsx
+++ b/amamenta-ui/src/pages/Default/Donations/RawMilkCollectionsPage.tsx
@@ -1,0 +1,380 @@
+import { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import {
+  BrButton,
+  BrInput,
+  BrModal,
+  BrTable,
+  BrTag,
+  type BrTableColumn,
+} from "@govbr-ds/react-components";
+
+import { api } from "@/services/api";
+import { useAuth } from "@/contexts/AuthContext/useAuth";
+import type { RawMilkCollection, RawMilkResponse, RawMilkFilterTab } from "@/types/rawMilk";
+
+import "./RawMilkCollectionsPage.css";
+
+const TABS: { key: RawMilkFilterTab; label: string }[] = [
+  { key: "PENDING", label: "Pendentes" },
+  { key: "APPROVED", label: "Aprovados" },
+  { key: "REJECTED", label: "Rejeitados" },
+  { key: "EXPIRED", label: "Vencidos" },
+];
+
+type Donator = { id: string; name: string };
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return new Intl.DateTimeFormat("pt-BR", { timeZone: "UTC" }).format(date);
+}
+
+function getStatusTag(status: RawMilkCollection["triageStatus"]) {
+  if (status === "APPROVED") return <BrTag color="success" value="Aprovado" />;
+  if (status === "REJECTED") return <BrTag color="danger" value="Rejeitado" />;
+  return <BrTag color="warning" value="Pendente" />;
+}
+
+export default function RawMilkCollectionsPage() {
+  const { user } = useAuth();
+
+  const [activeTab, setActiveTab] = useState<RawMilkFilterTab>("PENDING");
+  const [collections, setCollections] = useState<RawMilkCollection[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [isNewModalOpen, setIsNewModalOpen] = useState(false);
+  const [selected, setSelected] = useState<RawMilkCollection | null>(null);
+
+  async function loadCollections() {
+    setLoading(true);
+    setError(null);
+    try {
+      const query: Record<string, unknown> = { page, limit };
+      if (activeTab === "EXPIRED") query.expired = "true";
+      else query.triageStatus = activeTab;
+
+      const response = await api.get<RawMilkResponse>("/donations/raw-milk", {
+        params: query,
+      });
+      setCollections(response.data.data);
+      setTotal(response.data.meta.total);
+    } catch {
+      setError("Nao foi possivel carregar as coletas.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadCollections();
+  }, [activeTab, page, limit]);
+
+  function handleTabChange(tab: RawMilkFilterTab) {
+    setActiveTab(tab);
+    setPage(1);
+  }
+
+  const rows = useMemo(() => collections, [collections]);
+
+  const columns = useMemo<BrTableColumn<RawMilkCollection>[]>(
+    () => [
+     { key: "donorName", title: "Doadora", width: "24%", boldHeading: true, render: (v: unknown, row: RawMilkCollection) => (v as string | null) ?? row.donorId },
+      { key: "volumeMl", title: "Volume (ml)", width: "14%" },
+     { key: "expirationDate", title: "Validade", width: "16%", render: (v: unknown) => formatDate(String(v)) },
+     { key: "triageStatus", title: "Status", width: "16%", render: (v: unknown) => getStatusTag(v as RawMilkCollection["triageStatus"]) },
+         {
+        key: "id",
+        title: "Acoes",
+        align: "right",
+        width: "12%",
+        render: (_v: unknown, row: RawMilkCollection) => (
+          <BrButton
+            aria-label={`Ver detalhes da coleta de ${row.donorName ?? row.donorId}`}
+            circle
+            icon="eye"
+            size="small"
+            onClick={() => setSelected(row)}
+          />
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <section className="raw-milk-collections">
+      <header className="raw-milk-collections__header">
+        <div>
+          <h1 className="raw-milk-collections__title">Gestao de Coletas</h1>
+          <p className="raw-milk-collections__description">
+            Triagem e acompanhamento dos frascos de leite cru recebidos.
+          </p>
+        </div>
+        <BrButton icon="plus" primary onClick={() => setIsNewModalOpen(true)}>
+          Nova Coleta
+        </BrButton>
+      </header>
+
+      <div className="raw-milk-collections__tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            type="button"
+            className={
+              "raw-milk-collections__tab" +
+              (activeTab === tab.key ? " raw-milk-collections__tab--active" : "")
+            }
+            onClick={() => handleTabChange(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {error && <div className="raw-milk-collections__error">{error}</div>}
+
+      <div className="raw-milk-collections__table">
+        <BrTable
+          columns={columns}
+          data={rows}
+          density="small"
+          emptyContent="Nenhuma coleta encontrada."
+          isLoading={loading}
+          paginationProps={{
+            page,
+            perPage: limit,
+            total,
+            showTotalizers: true,
+            itemTitleSingular: "coleta",
+            itemTitlePlural: "coletas",
+            onPageChange: setPage,
+            onPerPageChange: setLimit,
+          }}
+          title="Coletas de leite cru"
+        />
+      </div>
+
+      <NewCollectionModal
+        isOpen={isNewModalOpen}
+        onClose={() => setIsNewModalOpen(false)}
+        createdBy={user?.id ?? ""}
+        onCreated={() => {
+          setIsNewModalOpen(false);
+          void loadCollections();
+        }}
+      />
+
+      <DetailsModal collection={selected} onClose={() => setSelected(null)} />
+    </section>
+  );
+}
+
+// --- Modal de Nova Coleta ---
+
+function NewCollectionModal({
+  isOpen,
+  onClose,
+  createdBy,
+  onCreated,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  createdBy: string;
+  onCreated: () => void;
+}) {
+  const [donorQuery, setDonorQuery] = useState("");
+  const [donorResults, setDonorResults] = useState<Donator[]>([]);
+  const [donor, setDonor] = useState<Donator | null>(null);
+  const [volumeMl, setVolumeMl] = useState("");
+  const [collectionDate, setCollectionDate] = useState("");
+  const [receivedAt, setReceivedAt] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!donorQuery || donorQuery === donor?.name) {
+      setDonorResults([]);
+      return;
+    }
+    const timeout = setTimeout(async () => {
+      const response = await api.get<{ data: Donator[] }>("/donators", {
+        params: { name: donorQuery, limit: 10 },
+      });
+      setDonorResults(response.data.data);
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [donorQuery, donor]);
+
+  function reset() {
+    setDonorQuery("");
+    setDonor(null);
+    setVolumeMl("");
+    setCollectionDate("");
+    setReceivedAt("");
+    setErrors({});
+  }
+
+  async function handleSubmit() {
+    const newErrors: Record<string, string> = {};
+    if (!donor) newErrors.donor = "Selecione a doadora";
+    if (!volumeMl || Number(volumeMl) <= 0) newErrors.volumeMl = "Informe o volume";
+    if (!collectionDate) newErrors.collectionDate = "Informe a data da coleta";
+    if (!receivedAt) newErrors.receivedAt = "Informe a data de recebimento";
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length > 0 || !donor) return;
+
+    setSubmitting(true);
+    try {
+      await api.post("/donations/raw-milk", {
+        donorId: donor.id,
+        volumeMl: Number(volumeMl),
+        collectionDate,
+        receivedAt,
+        createdBy,
+      });
+      reset();
+      onCreated();
+    } catch (err) {
+      let message = "Erro ao registrar coleta.";
+      if (axios.isAxiosError(err) && err.response?.data?.message) {
+        message = err.response.data.message;
+      }
+      setErrors({ general: message });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <BrModal
+      isOpen={isOpen}
+      onClose={onClose}
+      showClose
+      title="Nova Coleta"
+      primaryAction={{ label: submitting ? "Salvando..." : "Registrar", action: () => void handleSubmit() }}
+      secondaryAction={{ label: "Cancelar", action: onClose }}
+    >
+      <div className="raw-milk-collections__form">
+        <div className="raw-milk-collections__autocomplete">
+          <BrInput
+            label="Doadora"
+            placeholder="Buscar por nome"
+            value={donorQuery}
+            status={errors.donor ? "danger" : undefined}
+            feedbackText={errors.donor}
+            onChange={(e) => {
+              setDonorQuery(e.currentTarget.value);
+              setDonor(null);
+            }}
+          />
+          {donorResults.length > 0 && (
+            <ul className="raw-milk-collections__autocomplete-list">
+              {donorResults.map((d) => (
+                <li
+                  key={d.id}
+                  onClick={() => {
+                    setDonor(d);
+                    setDonorQuery(d.name);
+                    setDonorResults([]);
+                  }}
+                >
+                  {d.name}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <BrInput
+          type="number"
+          label="Volume (ml)"
+          value={volumeMl}
+          status={errors.volumeMl ? "danger" : undefined}
+          feedbackText={errors.volumeMl}
+          onChange={(e) => setVolumeMl(e.currentTarget.value)}
+        />
+        <BrInput
+          type="datetime-local"
+          label="Data da coleta"
+          value={collectionDate}
+          status={errors.collectionDate ? "danger" : undefined}
+          feedbackText={errors.collectionDate}
+          onChange={(e) => setCollectionDate(e.currentTarget.value)}
+        />
+        <BrInput
+          type="datetime-local"
+          label="Data de recebimento"
+          value={receivedAt}
+          status={errors.receivedAt ? "danger" : undefined}
+          feedbackText={errors.receivedAt}
+          onChange={(e) => setReceivedAt(e.currentTarget.value)}
+        />
+        {errors.general && <p className="raw-milk-collections__error">{errors.general}</p>}
+      </div>
+    </BrModal>
+  );
+}
+
+// --- Modal de Detalhes (substitui o "drawer" — a lib nao tem componente de drawer) ---
+
+const STEPS = ["Extraido", "Recebido", "Triado", "Utilizado / Descartado"];
+
+function getActiveStep(collection: RawMilkCollection) {
+  if (collection.storageStatus === "USED_IN_BATCH" || collection.storageStatus === "DISCARDED") return 3;
+  if (collection.triageStatus !== "PENDING") return 2;
+  return 1;
+}
+
+function DetailsModal({
+  collection,
+  onClose,
+}: {
+  collection: RawMilkCollection | null;
+  onClose: () => void;
+}) {
+  if (!collection) return null;
+  const activeStep = getActiveStep(collection);
+
+  return (
+    <BrModal isOpen showClose onClose={onClose} title="Detalhes da coleta">
+      <p><strong>Doadora:</strong> {collection.donorName ?? collection.donorId}</p>
+      <p><strong>Volume:</strong> {collection.volumeMl} ml</p>
+      <p><strong>Validade:</strong> {formatDate(collection.expirationDate)}</p>
+      <p><strong>Status:</strong> {getStatusTag(collection.triageStatus)}</p>
+
+      <h4>Linha do tempo</h4>
+      <ol className="raw-milk-collections__timeline">
+        {STEPS.map((step, index) => (
+          <li
+            key={step}
+            className={
+              "raw-milk-collections__timeline-item" +
+              (index < activeStep ? " raw-milk-collections__timeline-item--active" : "")
+            }
+          >
+            {step}
+          </li>
+        ))}
+      </ol>
+
+      {collection.observations && (
+        <>
+          <h4>Observacoes clinicas</h4>
+          <p>{collection.observations}</p>
+        </>
+      )}
+
+      {collection.triageStatus === "REJECTED" && (
+        <>
+          <h4>Motivo de descarte</h4>
+          <p>{collection.discardReason ?? "Nao informado"}</p>
+        </>
+      )}
+    </BrModal>
+  );
+}

--- a/amamenta-ui/src/routes/index.tsx
+++ b/amamenta-ui/src/routes/index.tsx
@@ -1,5 +1,4 @@
 import { createBrowserRouter, Navigate } from "react-router-dom";
-
 import AppShell from "@/layouts/AppShell/AppShell";
 import SuperAdminLayout from "@/layouts/SuperAdminLayout";
 import AcceptInvite from "@/pages/AcceptInvite/AcceptInvite";
@@ -11,12 +10,15 @@ import PendingExamsPage from "@/pages/Donators/PendingExamsPage";
 import LoginPage from "@/pages/Common/Login/Login";
 import ModulePlaceholder from "@/pages/ModulePlaceholder/ModulePlaceholder";
 import TenantAdminPanel from "@/pages/TenantAdmin/TenantAdminPanel";
+import RawMilkCollectionsPage from "@/pages/Default/Donations/RawMilkCollectionsPage";
 
 import {
   ALLOWED_DASHBOARD_ROLES,
   ALLOWED_SUPERADMIN_ROLES,
 } from "../constants/roles";
 import ProtectedRoute from "./ProtectedRoute";
+
+
 
 export const router = createBrowserRouter([
   {
@@ -77,13 +79,8 @@ export const router = createBrowserRouter([
       },
       {
         path: "doacoes/coletas",
-        element: (
-          <ModulePlaceholder
-            moduleName="Doacoes"
-            title="Coletas"
-            description="Registro e acompanhamento das coletas de leite cru."
-          />
-        ),
+       element: <RawMilkCollectionsPage />,
+        
       },
       {
         path: "doacoes/lotes",

--- a/amamenta-ui/src/types/rawMilk.ts
+++ b/amamenta-ui/src/types/rawMilk.ts
@@ -1,0 +1,24 @@
+export type TriageStatus = "PENDING" | "APPROVED" | "REJECTED";
+export type StorageStatus = "STORED" | "WAITING_BATCH" | "USED_IN_BATCH" | "EXPIRED" | "DISCARDED";
+
+export type RawMilkCollection = {
+    id: string;
+    donorId: string;
+    donorName?: string | null;
+    volumeMl: number;
+    collectionDate: string;
+    receivedAt: string;
+    expirationDate: string;
+    triageStatus: TriageStatus;
+    storageStatus: StorageStatus;
+    discardReason?: string | null;
+    observations?: string | null;
+    createdBy: string;
+};
+
+export type RawMilkResponse = {
+    data: RawMilkCollection[];
+    meta: { page: number; limit: number; total: number; totalPages: number };
+};
+
+export type RawMilkFilterTab = "PENDING" | "APPROVED" | "REJECTED" | "EXPIRED";


### PR DESCRIPTION
Implementa as Tasks 1.1 e 1.4 da issue #57.

## Task 1.1 — Tela Principal de Coletas
- Header com título e botão "Nova Coleta"
- Tabs (Pendentes/Aprovados/Rejeitados/Vencidos) com consulta dinâmica
- Modal de nova coleta, sem troca de rota
- Autocomplete de doadora com busca incremental
- Validade calculada automaticamente (collection_date + 15 dias), sem campo manual
- Bloqueio RDC 171 (received_at > expiration_date)
- Status inicial PENDING
- Feedback de erro/sucesso visível no modal

## Task 1.4 — Drawer de Detalhes
- Abre sem navegação (implementado como modal, já que a lib não possui componente de drawer)
- Exibe doadora, volume, validade, status
- Timeline (Extraído → Recebido → Triado → Utilizado/Descartado)
- Observações clínicas e motivo de descarte (quando REJECTED)

## Backend
- Adicionada regra RDC 171 no use-case (havia sido perdida em um merge anterior)
- Paginação (`data + meta`) e filtro de período em `GET /raw-milk`
- Join com nome da doadora na listagem
- Corrigido `rawMilk.routes.ts`: faltava o middleware `authenticate`, causando erro "Hospital não informado" (tenantId não era resolvido)

## Como testar
1. Acessar `/doacoes/coletas`
2. Clicar em "Nova Coleta", selecionar uma doadora com status Ativa
3. Confirmar validade calculada automaticamente
4. Testar bloqueio RDC 171 com data de recebimento > 15 dias após coleta
5. Abrir detalhes de uma coleta pelo ícone de olho

